### PR TITLE
Update the protocol

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
-swagger: '2.0'
+openapi: '3.0.0'
 info:
   description: Open source REST API for viewing and analyzing any type of logs or traces. Its goal is to provide models to populate views, graphs, metrics, and more to help extract useful information from traces, in a way that is more user-friendly and informative than huge text dumps.
   version: 0.0.0
@@ -24,8 +24,8 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-host: localhost:8080
-basePath: /tracecompass
+servers:
+  - url: 'http://localhost:8080/tracecompass'
 tags:
 - name: Traces
   description: How to manage physical traces on your server.
@@ -37,14 +37,12 @@ tags:
   description: Learn about querying XY models
 - name: TimeGraph
   description: Learn about querying Time Graph models.
-- name: Tables
-  description: Learn about querying table models.
-- name: Event Tables
-  description: Learn about querying event table models.
+- name: Virtual Tables
+  description: Learn about querying virtual table models (e.g. Events Table).
+- name: Filters
+  description: How to filter and query
 - name: Features
   description: Discover the features which are available on a given server.
-schemes:
-- http
 paths:
   /traces:
     get:
@@ -52,15 +50,15 @@ paths:
       - Traces
       summary: Get the list of physical traces imported on the server.
       operationId: getTraces
-      produces:
-      - application/json
       responses:
         200:
           description: Returns a list of traces
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/TraceModel'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TraceModel'
     post:
       tags:
       - Traces
@@ -68,32 +66,31 @@ paths:
       description: Import a trace to the trace server.
         Return some base information once imported.
       operationId: addTrace
-      consumes:
-      - application/x-www-form-urlencoded
-      - application/octet-stream
-      produces:
-      - application/json
-      parameters:
-      - name: path
-        in: formData
-        description: URL to the trace, not necessary if the trace is uploaded via the endpoint
+      requestBody:
         required: true
-        type: string
-      - name: name
-        in: formData
-        description: The name of the trace in the server, to override the default name
-        required: false
-        type: string
-      - name: typeID
-        in: formData
-        description: The trace type's id, to force the use of a parser / disambiguate the trace type.
-        required: false
-        type: string
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                path:
+                  description: URL to the trace, not necessary if the trace is uploaded via the endpoint
+                  type: string
+                name:
+                  description: The name of the trace in the server, to override the default name
+                  type: string
+                typeID:
+                  description: The trace type's id, to force the use of a parser / disambiguate the trace type.
+                  type: string
+              required:
+                - path
       responses:
         200:
           description: The trace has been successfully added to the trace server.
-          schema:
-            $ref: '#/definitions/TraceModel'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TraceModel'
         404:
           description: "No trace available at path"
         406:
@@ -107,20 +104,21 @@ paths:
       summary: Remove a trace from the server.
         Does not delete the trace from disk.
       operationId: deleteTrace
-      produces:
-      - application/json
       parameters:
       - name: traceUUID
         in: path
         description: The unique identifier of the trace in the server
         required: true
-        type: integer
-        format: int128
+        schema:
+          type: integer
+          format: int128
       responses:
         200:
           description: The trace was successfully deleted
-          schema:
-            $ref: '#/definitions/TraceModel'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TraceModel'
         204:
           description: There was no trace with this name to close / delete
   /experiments:
@@ -129,44 +127,47 @@ paths:
       - Experiments
       summary: Get the list of experiments on the server
       operationId: getExperiments
-      produces:
-      - application/json
       responses:
         200:
           description: Returns a list of experiments
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Experiment'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Experiment'
     post:
       summary: Create a new experiment on the server
       operationId: postExperiment
       tags:
       - Experiments
       - Traces
-      consumes:
-      - application/x-www-form-urlencoded
-      produces:
-      - application/json
-      parameters:
-      - name: name
-        in: formData
-        description: The name to give this experiment
+      requestBody:
         required: true
-        type: string
-      - name: traces
-        in: formData
-        description: The unique identifiers of the traces to encapsulate in this experiment
-        required: true
-        type: array
-        items:
-          type: integer
-          format: int128
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: The name to give this experiment
+                  type: string
+                traces:
+                  description: The unique identifiers of the traces to encapsulate in this experiment
+                  type: array
+                  items:
+                    type: integer
+                    format: int128
+              required:
+                - name
+                - traces
       responses:
         200:
           description: The Experiment was successfully created
-          schema:
-            $ref: '#/definitions/Experiment'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
   /experiments/{expUUID}:
     get:
       summary: Get the Model object for an experiment
@@ -174,20 +175,21 @@ paths:
       tags:
       - Experiments
       - Traces
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to modify
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       responses:
         200:
           description: Return the experiment model
-          schema:
-            $ref: '#/definitions/Experiment'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
         400:
           description: No such experiment
     put:
@@ -196,52 +198,56 @@ paths:
       tags:
       - Experiments
       - Traces
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to modify
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       - name: name
         in: query
         description: The name to give this experiment
         required: true
-        type: string
+        schema:
+          type: string
       - name: UUID
         in: query
         description: The unique identifiers of the traces to encapsulate in this experiment
         required: true
-        type: array
-        items:
-          type : integer
-          format: int128
+        schema:
+          type: array
+          items:
+            type : integer
+            format: int128
       responses:
         200:
           description: The Experiment was successfully modified
-          schema:
-            $ref: '#/definitions/Experiment'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
     delete:
       tags:
       - Experiments
       summary: Remove an Experiment from the server.
       operationId: deleteExperiment
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The unique identifier of the experiment in the server
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       responses:
         200:
           description: The trace was successfully deleted, return the deleted experiment.
-          schema:
-            $ref: '#/definitions/Experiment'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Experiment'
         204:
           description: There was no experiment with this name to close / delete
   /experiments/{expUUID}/outputs:
@@ -250,378 +256,435 @@ paths:
       - Traces
       summary: Get the list of outputs for this experiment
       operationId: getOutputs
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The unique identifier of the experiment in the server
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       responses:
         200:
           description: Returns a list of output provider descriptors
-          schema:
-            type: object
-            properties:
-              experiment:
-                $ref: '#/definitions/Experiment'
-              providers:
-                type: array
-                items:
-                  $ref: '#/definitions/OutputDescriptor'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  experiment:
+                    $ref: '#/components/schemas/Experiment'
+                  providers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OutputDescriptor'
         404:
           description: No such trace
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/bookmarks:
     get:
       summary: Get the collection of bookmarks for an experiment.
       operationId: getExperimentBookmarks
       tags:
       - Bookmarks
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       responses:
         200:
           description: Returns a list of bookmarks for this trace
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Bookmark'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Bookmark'
         404:
           description: No such experiment
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
     post:
       summary: Add a bookmark to an experiment.
       operationId: postExperimentBookmark
       tags:
       - Bookmarks
-      consumes:
-      - application/json
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type : integer
-        format: int128
-      - name: bookmark
-        in: body
+        schema:
+          type : integer
+          format: int128
+      requestBody:
         description: The bookmark to post
         required: true
-        schema:
-            $ref: '#/definitions/Bookmark'
+        content:
+          application/json:
+            schema:
+                $ref: '#/components/schemas/Bookmark'         
       responses:
         200:
           description: Returns the boomark's Id
-          schema:
-            type: integer
+          content:
+            application/json:
+              schema:
+                type: integer
         404:
           description: No such trace
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/bookmarks/{bookmarkId}:
     get:
       summary: Get a specific bookmark from this experiment
       operationId: getExperimentBookmark
       tags:
       - Bookmarks
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       - name: bookmarkId
         in: path
         description: The unique identifier of the bookmark to get
         required: true
-        type: integer
-        format: int128
+        schema:
+          type: integer
+          format: int128
       responses:
         200:
           description: Returns the queried bookmark
-          schema:
-            $ref: '#/definitions/Bookmark'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
         404:
           description: No such experiment / No such bookmark
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
     put:
       summary: Modify a bookmark
       operationId: putExperimentBookmark
       tags:
       - Bookmarks
-      consumes:
-      - application/json
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type: integer
-        format: int128
+        schema:
+          type: integer
+          format: int128
       - name: bookmarkId
         in: path
         description: The unique identifier of the bookmark to modify
         required: true
-        type: string
-      - name: bookmark
-        in: body
+        schema:
+          type: string
+      requestBody:
         description: The bookmark to update
         required: true
-        schema:
-            $ref: '#/definitions/Bookmark'
+        content:
+          application/json:
+            schema:
+                $ref: '#/components/schemas/Bookmark' 
       responses:
         200:
           description: Returns the boomark's Id
-          schema:
-            type: integer
+          content:
+            application/json:
+              schema:
+                type: integer
         404:
           description: No such trace
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
     delete:
       summary: Delete a bookmark
       operationId: deleteExperimentBookmark
       tags:
       - Bookmarks
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type: integer
-        format: int128
+        schema:
+          type: integer
+          format: int128
       - name: bookmarkId
         in: path
         description: The unique identifier of the bookmark to delete
         required: true
-        type: integer
-        format: int128
+        schema:
+          type: integer
+          format: int128
       responses:
         200:
           description: Returns the deleted boomark
-          schema:
-            $ref: '#/definitions/Bookmark'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bookmark'
         404:
           description: No such trace or bookmark
-          schema:
-            type: string
-  /experiments/{expUUID}/outputs/{outputID}/tree:
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/XY/{outputID}/tree:
     get:
       tags:
       - XY
-      - TimeGraph
-      - Tables
-      - Event Tables
-      summary: Tentative API for the XY and Time Graph models.
+      summary: Tentative API for the XY models.
       description: Unique entry point for output providers,
         to get the tree of visible entries
-      operationId: getOutput
-      consumes:
-      - application/x-www-form-urlencoded
-      produces:
-      - application/json
+      operationId: getXYEntry
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to query
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       - name: outputID
         in: path
         description: ID of the output provider to query
-        type: string
         required: true
-      - name: low
+        schema:
+          type: string
+      - name: queryFilterID
         in: query
-        description: Low index for the virtual tree / batching
-        required: false
-        type: integer
-        format: int64
-      - name: size
-        in: query
-        description: Number of entries for the virtual tree / batching
-        required: false
-        type: integer
-        format: int32
-      - name: start
-        in: query
-        description: Start Time of the query
-        required: false
-        type: integer
-        format: int64
-      - name: end
-        in: query
-        description: End Time of the query
-        required: false
-        type: integer
-        format: int64
+        description: Filter ID previously created
+        schema:
+          type: integer
+          format: int32
       responses:
         200:
-          description: Returns a list of XY entries, Time graph entries or table headers. The returned model must be consistent, parentIds must refer to a parent which exists in the model.
-          schema:
-            type: object
-            properties:
-              output:
-                $ref: '#/definitions/OutputDescriptor'
-              entries:
-                type: array
-                items:
-                  $ref: '#/definitions/TimeGraphEntry'
-              size:
-                description: total number of entries for this model.
-                type: integer
-                format: int64
+          description: Returns a list of XY entries. The returned model must be consistent, parentIds must refer to a parent which exists in the model.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    $ref: '#/components/schemas/OutputDescriptor'
+                  headers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EntryHeader'
+                  entries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/XYEntry'
+                  size:
+                    description: total number of entries for this model.
+                    type: integer
+                    format: int64
         404:
           description: Experiment or output provider not found
-          schema:
-            type: string
-  /experiments/{expUUID}/outputs/{tableId}/lines:
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/timeGraph/{outputID}/tree:
     get:
       tags:
-      - Tables
-      - Event Tables
+      - TimeGraph
+      summary: Tentative API for Time Graph models.
+      description: Unique entry point for output providers,
+        to get the tree of visible entries
+      operationId: getTimeGraphEntry
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
+        in: path
+        description: ID of the output provider to query
+        required: true
+        schema:
+          type: string
+      - name: queryFilterID
+        in: query
+        description: Filter ID previously created
+        schema:
+          type: integer
+          format: int32
+      responses:
+        200:
+          description: Returns a list Time graph entries. The returned model must be consistent, parentIds must refer to a parent which exists in the model.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    $ref: '#/components/schemas/OutputDescriptor'
+                  headers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EntryHeader'
+                  entries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TimeGraphEntry'
+                  size:
+                    description: total number of entries for this model.
+                    type: integer
+                    format: int64
+        404:
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/table/{outputID}/columns:
+    get:
+      tags:
+      - Virtual Tables
+      summary: Tentative API for events table models.
+      description: Unique entry point for output providers, to get the column entries.
+      operationId: getEventsTableEntry
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
+        in: path
+        description: ID of the output provider to query
+        required: true
+        schema:
+          type: string
+      - name: queryFilterID
+        in: query
+        description: Filter ID previously created
+        schema:
+          type: integer
+          format: int32
+      responses:
+        200:
+          description: Returns a list of table headers.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    $ref: '#/components/schemas/OutputDescriptor'
+                  entries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ColumnHeaderEntry'
+                  size:
+                    description: total number of entries for this model.
+                    type: integer
+                    format: int64
+        404:
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/table/{outputID}/lines:
+    get:
+      tags:
+      - Virtual Tables
       summary: Get a virtual table of the items from a table
       operationId: getLines
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: The UUID of the experiment in the server
         required: true
-        type : integer
-        format: int128
-      - name: tableId
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
         in: path
         description: The name of the table provider to query
         required: true
-        type: string
+        schema:
+          type: string
       - name: lowIndex
         in: query
         description: Index of the first line to query
         required: true
-        type: integer
-        format: int64
-        minimum: 0
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
       - name: size
         in: query
         description: Number of events to query
         required: true
-        type: integer
-        format: int32
+        schema:
+          type: integer
+          format: int32
       - name: columnId
         in: query
-        type: array
-        items:
-          type: string
         description: List of column ids to return, all columns will be returned if not specified. The data in the returned lines will use the same order as the columnId array.
         required: false
+        schema:
+          type: array
+          items:
+            type: string
       responses:
         200:
           description: Returns a table model with a 2D array of strings and metadata
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/TableModel'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TableModel'
         400:
           description: Bad request, the top index and size must be larger than 0
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
         404:
           description: No such Experiment
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
         500:
           description: Error reading the Experiment
-          schema:
-            type: string
-    put:
-      tags:
-      - Event Tables
-      summary: Get an virtual table of the items from a table
-      produces:
-      - application/json
-      consumes:
-      - application/x-www-form-urlencoded
-      parameters:
-      - name: expUUID
-        in: path
-        description: The UUID of the experiment in the server
-        required: true
-        type : integer
-        format: int128
-      - name: tableId
-        in: path
-        description: The name of the table provider to query
-        required: true
-        type: string
-      - name: lowIndex
-        in: query
-        description: Index of the first line to query
-        required: true
-        type: integer
-        format: int64
-        minimum: 0
-      - name: size
-        in: query
-        description: Number of lines to query
-        required: true
-        type: integer
-        format: int32
-      - name: columnId
-        in: query
-        type: array
-        items:
-          type: string
-        description: List of column IDs to return, all columns will be returned if not specified. The data in the returned lines will use the same order as the columnId array.
-        required: false
-      - name: filters
-        in: formData
-        type: string
-        description: The form data contains an array of preset filter ID (Key presetfilterId), a boolean to determine of a collapse filter is applied (Key collapseFilter) and a map of column IDs to their regular expressions to apply to filter the columns. Preset filter are filters that are defined outside the table and can be found on the server. The collapse filter, when applied, will collapse two or more consecutive lines together if they are identical and the returned lines will have a count of how many lines were collapsed.
-        required: false
-      responses:
-        200:
-          description: Returns a table model with a 2D array of strings and metadata
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/TableModel'
-        400:
-          description: Bad request, the top index and size must be larger than 0
-          schema:
-            type: string
-        404:
-          description: No such Experiment
-          schema:
-            type: string
-        500:
-          description: Error reading the Experiment
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/{outputID}/tooltip:
     get:
       tags:
@@ -631,55 +694,62 @@ paths:
       description: Unique entry point for all XY and Time Graph views,
         to get the tree of visible entrie
       operationId: getTooltip
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to query
         required: true
-        type : integer
-        format: int128
+        schema:
+          type : integer
+          format: int128
       - name: outputID
         in: path
         description: ID of the output provider to query
-        type: string
         required: true
+        schema:
+          type: string
       - name: time
         in: query
         description: Tooltip's timestamp.
         required: true
-        type: integer
-        format: int64
+        schema:
+          type: integer
+          format: int64
       - name: entryID
         in: query
         description: Tooltip's entry, a global tooltip is returned if absent.
         required: false
-        type: integer
-        format: int64
+        schema:
+          type: integer
+          format: int64
       - name: targetID
         in: query
         description: Tooltip's entry, when applied on arrows.
         required: false
-        type: integer
-        format: int64
+        schema:
+          type: integer
+          format: int64
       responses:
         200:
           description: Returns a list of tooltip keys to values
-          schema:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
         404:
           description: Experiment or output provider not found
-          schema:
-            type: string
-  /experiments/{expUUID}/outputs/{xyOutputID}/xy:
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/XY/{outputID}/xy:
     get:
       tags:
       - XY
@@ -687,62 +757,46 @@ paths:
       description: Unique endpoint for all xy models,
         ensures that the same template is followed for all endpoints.
       operationId: getXY
-      consumes:
-      - application/x-www-form-urlencoded
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to query
         required: true
-        type : integer
-        format: int128
-      - name: xyOutputID
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
         in: path
         description: ID of the output provider to query
-        type: string
         required: true
-      - name: start
+        schema:
+          type: string
+      - name: queryFilterID
         in: query
-        description: Start Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: end
-        in: query
-        description: End Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: nb
-        in: query
-        description: Number of data points to sample
-        required: true
-        type: integer
-        format: int32
-      - name: ids
-        in: query
-        description: Parameters to query specific entries
-        required: true
-        type: array
-        items:
+        description: Filter ID previously created
+        schema:
           type: integer
-          format: int64
+          format: int32
       responses:
         200:
           description: Return the queried XYView
-          schema:
-            $ref: '#/definitions/XYView'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/XYView'
         404:
           description: Trace not found
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
         405:
           description: Analysis not possible for this trace
-          schema:
-            type: string
-  /experiments/{expUUID}/outputs/{timeGraphID}/states:
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/timeGraph/{outputID}/states:
     get:
       tags:
       - TimeGraph
@@ -750,71 +804,47 @@ paths:
       operationId: getTimeGraphStates
       description: Unique entry point for all TimeGraph states,
         ensures that the same template is followed for all views
-      consumes:
-      - application/x-www-form-urlencoded
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiement to query
         required: true
-        type : integer
-        format: int128
-      - name: timeGraphID
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
         in: path
         description: ID of the output provider to query
-        type: string
         required: true
-      - name: start
+        schema:
+          type: string
+      - name: queryFilterID
         in: query
-        description: Start Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: end
-        in: query
-        description: End Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: nb
-        in: query
-        description: Number of time stamps to sample
-        required: true
-        type: integer
-        format: int32
-      - name: entries
-        in: query
-        required: true
-        type: array
-        items:
+        description: Filter ID previously created
+        schema:
           type: integer
-          format: int64
-        description: List of entries to query
-      - name: labelRatio
-        in: query
-        description: Ratio of state duration to label's string length to determine if the resolution is large enough to return the label
-        required: false
-        type: integer
-        format: int32
+          format: int32
       responses:
         200:
           description: Returns a list of trace entries
-          schema:
-            type: object
-            properties:
-              trace:
-                $ref: '#/definitions/TraceModel'
-              states:
-                type: array
-                items:
-                  $ref: '#/definitions/TimeGraphRow'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  trace:
+                    $ref: '#/components/schemas/TraceModel'
+                  states:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TimeGraphRow'
         404:
           description: Experiment or output provider not found
-          schema:
-            type: string
-  /experiments/{expUUID}/outputs/{timeGraphID}/arrows:
+          content:
+            application/json:
+              schema:
+                type: string
+  /experiments/{expUUID}/outputs/timeGraph/{outputID}/arrows:
     get:
       tags:
       - TimeGraph
@@ -822,89 +852,76 @@ paths:
       operationId: getTimeGraphArrows
       description: Unique entry point for all TimeGraph models,
         ensures that the same template is followed for all models
-      consumes:
-      - application/json
-      produces:
-      - application/json
       parameters:
       - name: expUUID
         in: path
         description: UUID of the experiment to query
         required: true
-        type : integer
-        format: int128
-      - name: timeGraphID
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
         in: path
         description: ID of the output provider to query
-        type: string
         required: true
-      - name: start
+        schema:
+          type: string
+      - name: queryFilterID
         in: query
-        description: Start Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: end
-        in: query
-        description: End Time of the query
-        required: true
-        type: integer
-        format: int64
-      - name: nb
-        in: query
-        description: Number of time stamps to sample
-        required: true
-        type: integer
-        format: int32
-      - name: arrowSeries
-        in: query
-        description: Name of the arrow series to query, return the default series if absent.
-        required: false
-        type: string
+        description: Filter ID previously created
+        schema:
+          type: integer
+          format: int32
       responses:
         200:
           description: Returns a sampled list of TimeGraph arrows
-          schema:
-            type: object
-            properties:
-              output:
-                $ref: '#/definitions/OutputDescriptor'
-              arrows:
-                type: array
-                items:
-                  $ref: '#/definitions/TimeGraphArrow'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  output:
+                    $ref: '#/components/schemas/OutputDescriptor'
+                  arrows:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TimeGraphArrow'
         404:
           description: Experiment or output provider not found
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                type: string
   /symbols/{hostID}/{PID}:
     post:
       tags:
       - Symbols
       summary: Import/Upload a symbol provider.
       operationId: addSymbolProvider
-      consumes:
-      - application/x-www-form-urlencoded
-      - application/binary
-      produces:
-      - application/json
       parameters:
       - name: hostID
         in: path
         description: Host ID for the symbol provider
         required: true
-        type: string
+        schema:
+          type: string
       - name: PID
         in: path
         description: PID for the symbol provider
         required: true
-        type: string
-      - name: url
-        in: formData
-        description: URL to the symbol provider, not required if the symbol provider is
-          uploaded directly to the endpoint.
-        required: false
-        type: string
+        schema:
+          type: string
+      requestBody:
+        description: URL to the symbol provider, not required if the symbol provider is uploaded directly to the endpoint.
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                url:
+                  description: URL to the symbol provider, not required if the symbol provider is uploaded directly to the endpoint.
+                  type: string
       responses:
         200:
           description: The symbol provider has been successfully added to the trace server.
@@ -915,338 +932,541 @@ paths:
       - Symbols
       summary: Gets the symbol providers
       operationId: getSymbols
-      produces:
-      - application/json
       parameters:
       - name: hostID
         in: path
         description: The host's ID
         required: true
-        type: string
+        schema:
+          type: string
       - name: PID
         in: path
         description: Process ID
         required: true
-        type: string
+        schema:
+          type: string
       responses:
         200:
           description: Returns the Symbol providers for this query.
         404:
           description: No such Host, Thread and address combination.
+  /filters:
+    get:
+      summary: Get the list of filters available.
+      operationId: getFilters
+      tags:
+      - Filters
+      responses:
+        200:
+          description: List of filters available.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Filter'
+    post:
+      summary: Create a new filter.
+      operationId: addFilter
+      tags:
+      - Filters
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Human readable label for this filter
+                  type: string
+                filterType:
+                  description: Type of the filter
+                  type: string
+                  enum: [query, expression]
+                start:
+                  description: start time for this filter
+                  type: integer
+                  format: int64
+                end:
+                  description: end time for this filter
+                  type: integer
+                  format: int64
+                queryObject:
+                  description: query object
+                  type: object
+                filterExpression:
+                  description: expression from the filter language
+                  type: string
+              required:
+                - filterType
+                - start
+                - end
+                - queryObject
+                - filterExpression
+      responses:
+        200:
+          description: Created filter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter'
+  /filters/{filterID}:
+    get:
+      summary: Get the filter with the given ID.
+      operationId: getFilter
+      tags:
+      - Filters
+      parameters:
+      - name: filterID
+        description: Filter ID
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        200:
+          description: The filter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter'
+    put:
+      summary: Update the given filter.
+      operationId: updateFilter
+      tags:
+      - Filters
+      parameters:
+      - name: filterID
+        description: Filter ID
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Human readable label for this filter
+                  type: string
+                filterType:
+                  description: Type of the filter
+                  type: string
+                  enum: [query, expression]
+                start:
+                  description: start time for this filter
+                  type: integer
+                  format: int64
+                end:
+                  description: end time for this filter
+                  type: integer
+                  format: int64
+                queryObject:
+                  description: query object
+                  type: object
+                filterExpression:
+                  description: expression from the filter language
+                  type: string
+      responses:
+        200:
+          description: The filter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter'
   /about/traceTypes:
     get:
       summary: Get the list of trace types supported by this server.
       operationId: getTraceTypes
       tags:
       - Features
-      produces:
-      - application/json
       responses:
         200:
           description: List of the trace types supported by this server.
-          schema:
-            type: array
-            items:
-              type: object
-              properties:
-                ID:
-                  description: The unique identifier for this trace type
-                  type: string
-                description:
-                  description: Human readable description of this trace type
-                  type: string
-                versions:
-                  description: List supported versions
-                  type: array
-                  items:
-                    type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    ID:
+                      description: The unique identifier for this trace type
+                      type: string
+                    description:
+                      description: Human readable description of this trace type
+                      type: string
+                    versions:
+                      description: List supported versions
+                      type: array
+                      items:
+                        type: string
   /about/outputTypes:
     get:
       summary: Get the list of outputs supported by this server.
       tags:
       - Features
-      produces:
-      - application/json
       responses:
         200:
           description: List of the output types supported by this server.
-          schema:
-            type: array
-            items:
-              type: object
-              properties:
-                ID:
-                  description: The unique identifier for this output provider type
-                  type: string
-                description:
-                  description: Human readable description of this output type
-                  type: string
-                versions:
-                  description: List supported versions
-                  type: array
-                  items:
-                    type: string
-definitions:
-  TraceModel:
-    type: object
-    properties:
-      name:
-        description: User defined name for the trace
-        type: string
-      path:
-        description: Path to the trace on the file server's File System
-        type: string
-      nbEvents:
-        description: Current number of indexed events in the trace.
-        type: integer
-        format: int64
-      startTime:
-        description: The trace's start time
-        type: integer
-        format: int64
-      endTime:
-        description: The trace's end time
-        type: integer
-        format: int64
-      UUID:
-        description: The trace's unique identifier
-        type : integer
-        format: int128
-  Experiment:
-    type: object
-    properties:
-      name:
-        description: User defined name for the experiment
-        type: string
-      nbEvents:
-        description: Current number of indexed events in the trace.
-        type: integer
-        format: int64
-      startTime:
-        description: The trace's start time
-        type: integer
-        format: int64
-      endTime:
-        description: The trace's end time
-        type: integer
-        format: int64
-      UUID:
-        description: The experiment's unique identifier
-        type : integer
-        format: int128
-      traces:
-        description: The traces encapsulated by this experiment
-        type: array
-        items:
-          $ref: '#/definitions/TraceModel'
-  Bookmark:
-    type: object
-    properties:
-      start:
-        description: the start time for this bookmark.
-        type: integer
-        format: int64
-      end:
-        description: the end time for this bookmark.
-        type: integer
-        format: int64
-      name:
-        description: this bookmark's name
-        type: string
-      type:
-        description: The type of the bookmark (generic, output, ...)
-        type: string
-      iconUrl:
-        description: URL to the bookmark's icon
-        type: string
-      UUID:
-        description: The bookmark's unique ID, generated by the server.
-        type: integer
-        format: int128
-  OutputDescriptor:
-    type: object
-    properties:
-      ID:
-        description: The output provider's ID
-        type: string
-      name:
-        description: The human readable name
-        type: string
-      description:
-        description: Describe the output provider's features
-        type: string
-      start:
-        description: The start time of the output model
-        type: integer
-        format: int64
-      end:
-        description: The end time of the output model
-        type: integer
-        format: int64
-      final:
-        description: If the start, end times and current model are final, or if they will need to be refreshed later to represent a more up to date version.
-        type: boolean
-  TableModel:
-    type: object
-    properties:
-      trace:
-        $ref: '#/definitions/TraceModel'
-      lowIndex:
-        description: Rank of the first returned event
-        type: integer
-        format: int64
-      size:
-        description: Number of events. If filtered, the size will be the number of events that match the filters
-        type: integer
-        format: int32
-      columnId:
-        type: array
-        items:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    ID:
+                      description: The unique identifier for this output provider type
+                      type: string
+                    description:
+                      description: Human readable description of this output type
+                      type: string
+                    versions:
+                      description: List supported versions
+                      type: array
+                      items:
+                        type: string
+components:
+  schemas:
+    TraceModel:
+      type: object
+      properties:
+        name:
+          description: User defined name for the trace
+          type: string
+        path:
+          description: Path to the trace on the file server's File System
+          type: string
+        nbEvents:
+          description: Current number of indexed events in the trace.
           type: integer
           format: int64
-      lines:
-        type: array
-        items:
-          $ref: '#/definitions/LineModel'
-  LineModel:
-    type: object
-    properties:
-      index:
-        type: integer
-        format: int64
-      line:
-        type: array
-        items:
+        startTime:
+          description: The trace's start time
+          type: integer
+          format: int64
+        endTime:
+          description: The trace's end time
+          type: integer
+          format: int64
+        UUID:
+          description: The trace's unique identifier
+          type : integer
+          format: int128
+    Experiment:
+      type: object
+      properties:
+        name:
+          description: User defined name for the experiment
           type: string
-  XYEntry:
-    type: object
-    properties:
-      name:
-        description: Displayed name for this Entry
-        type: string
-      id:
-        description: Unique id to identify this entry in the backend.
-        type: integer
-        format: int64
-      parentId:
-        description: Unique id to identify this parent's entry,
-          optional if this entry does not have a parent.
-        type: integer
-        format: int64
-      cssId:
-        description: Optional reference to the CSS class to format this entry's series.
-        type: integer
-        format: int32
-  XYView:
-    type: object
-    properties:
-      trace:
-        $ref: '#/definitions/TraceModel'
-      model:
-        type: object
-        properties:
-          times:
-            description: X values (times) for the XY Model
-            type: array
-            items:
-              type: integer
-              format: int64
-          series:
-            description: map of series' name to Y series model
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  description: series' name
-                  type: string
-                values:
-                  description: series' Y values
-                  type: array
-                  items:
-                    type: number
-                    format: double
-      xLabel:
-        description: Label to apply to the x-axis
-        type: string
-      yLabel:
-        description: Label to apply to the y-axis
-        type: string
-  TimeGraphEntry:
-    type: object
-    properties:
-      name:
-        description: Displayed name for this Entry
-        type: string
-      id:
-        description: Unique id to identify this entry in the backend.
-        type: integer
-        format: int32
-      parentId:
-        description: Unique id to identify this parent's entry.
-        type: integer
-        format: int32
-      start:
-        description: Beginning of the range for which this entry exists
-        type: integer
-        format: int64
-      end:
-        description: End of the range for which this entry exists
-        type: integer
-        format: int64
-  TimeGraphState:
-    type: object
-    properties:
-      start:
-        description: start time for this state
-        type: integer
-        format: int64
-      end:
-        description: end time for this state
-        type: integer
-        format: int64
-      label:
-        description: Text label to apply to this TimeGraphState if resolution permits.
-          Optional, no label is applied if absent.
-        type: string
-      cssId:
-        description: optional ID to refer to the css to format this arrow
-        type: integer
-      cssValue:
-        description: optional value to vary css rendering
-        type: integer
-  TimeGraphRow:
-    type: object
-    properties:
-      id:
-        description: The entry to map this state list to
-        type: integer
-        format: int64
-      states:
-        description: List of the time graph entry states associated to this entry and zoom level.
-        type: array
-        items:
-          $ref: '#/definitions/TimeGraphState'
-  TimeGraphArrow:
-    type: object
-    properties:
-      start:
-        description: start time for this arrow
-        type: integer
-        format: int64
-      end:
-        description: end time for this arrow
-        type: integer
-        format: int64
-      sourceId:
-        description: Source entry's unique ID
-        type: integer
-        format: int64
-      targetId:
-        description: Target entry's unique ID
-        type: integer
-        format: int64
-      cssId:
-        description: optional ID to refer to the css to format this arrow
-        type: integer
-        format: int32
+        nbEvents:
+          description: Current number of indexed events in the trace.
+          type: integer
+          format: int64
+        startTime:
+          description: The trace's start time
+          type: integer
+          format: int64
+        endTime:
+          description: The trace's end time
+          type: integer
+          format: int64
+        UUID:
+          description: The experiment's unique identifier
+          type : integer
+          format: int128
+        traces:
+          description: The traces encapsulated by this experiment
+          type: array
+          items:
+            $ref: '#/components/schemas/TraceModel'
+    Bookmark:
+      type: object
+      properties:
+        start:
+          description: the start time for this bookmark.
+          type: integer
+          format: int64
+        end:
+          description: the end time for this bookmark.
+          type: integer
+          format: int64
+        name:
+          description: this bookmark's name
+          type: string
+        type:
+          description: The type of the bookmark (generic, output, ...)
+          type: string
+        iconUrl:
+          description: URL to the bookmark's icon
+          type: string
+        UUID:
+          description: The bookmark's unique ID, generated by the server.
+          type: integer
+          format: int128
+    OutputDescriptor:
+      type: object
+      properties:
+        ID:
+          description: The output provider's ID
+          type: string
+        name:
+          description: The human readable name
+          type: string
+        description:
+          description: Describe the output provider's features
+          type: string
+        responseType:
+          description: Type of data returned by this output. Serve as a hint to determine what kind of view should be use for this output (ex. XY, Time Graph, Table, etc..)
+          type: string
+        queryParameters:
+          description: List all the possible paramaters that can be use to query this output.
+          type: object
+          additionalProperties:
+            type: object
+        start:
+          description: The start time of the output model
+          type: integer
+          format: int64
+        end:
+          description: The end time of the output model
+          type: integer
+          format: int64
+        final:
+          description: If the start, end times and current model are final, or if they will need to be refreshed later to represent a more up to date version.
+          type: boolean
+    TableModel:
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/TraceModel'
+        lowIndex:
+          description: Rank of the first returned event
+          type: integer
+          format: int64
+        size:
+          description: Number of events. If filtered, the size will be the number of events that match the filters
+          type: integer
+          format: int32
+        columnId:
+          type: array
+          items:
+            type: integer
+            format: int64
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineModel'
+    LineModel:
+      type: object
+      properties:
+        index:
+          type: integer
+          format: int64
+        line:
+          type: array
+          items:
+            type: string
+    ColumnHeaderEntry:
+      type: object
+      properties:
+        name:
+          description: Displayed name for this column
+          type: string
+        columnDescription:
+          description: Description of the column
+          type: string
+        id:
+          description: Unique id to identify this column in the backend.
+          type: integer
+          format: int32
+        parentId:
+          description: Unique id to identify this parent's entry.
+          type: integer
+          format: int32
+    EntryHeader:
+      type: object
+      properties:
+        name:
+          description: Displayed name for this header
+          type: string
+    XYEntry:
+      type: object
+      properties:
+        name:
+          description: Displayed name for this Entry
+          type: array
+          items:
+            type: string
+        id:
+          description: Unique id to identify this entry in the backend.
+          type: integer
+          format: int64
+        parentId:
+          description: Unique id to identify this parent's entry,
+            optional if this entry does not have a parent.
+          type: integer
+          format: int64
+    XYView:
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/TraceModel'
+        model:
+          type: object
+          properties:
+            xValues:
+              description: X values for the XY Model
+              type: array
+              items:
+                type: integer
+                format: int64
+            series:
+              description: map of series' name to Y series model
+              type: array
+              items:
+                type: object
+                properties:
+                  seriesName:
+                    description: series' name
+                    type: string
+                  yValues:
+                    description: series' Y values
+                    type: array
+                    items:
+                      type: number
+                      format: double
+        xAxis:
+          type: object
+          properties:
+            label:
+              description: Label to apply to the x-axis
+              type: string
+            unit:
+              description: Type of units used for this axis
+              type: string
+        yAxis:
+          type: object
+          properties:
+            label:
+              description: Label to apply to the y-axis
+              type: string
+            unit:
+              description: Type of units used for this axis
+              type: string
+    TimeGraphEntry:
+      type: object
+      properties:
+        name:
+          description: Displayed name for this Entry
+          type: array
+          items:
+            type: string
+        id:
+          description: Unique id to identify this entry in the backend.
+          type: integer
+          format: int32
+        parentId:
+          description: Unique id to identify this parent's entry.
+          type: integer
+          format: int32
+        start:
+          description: Beginning of the range for which this entry exists
+          type: integer
+          format: int64
+        end:
+          description: End of the range for which this entry exists
+          type: integer
+          format: int64
+    TimeGraphState:
+      type: object
+      properties:
+        start:
+          description: start time for this state
+          type: integer
+          format: int64
+        end:
+          description: end time for this state
+          type: integer
+          format: int64
+        label:
+          description: Text label to apply to this TimeGraphState if resolution permits.
+            Optional, no label is applied if absent.
+          type: string
+        cssId:
+          description: optional ID to refer to the css to format this arrow
+          type: integer
+        cssValue:
+          description: optional value to vary css rendering
+          type: integer
+    TimeGraphRow:
+      type: object
+      properties:
+        id:
+          description: The entry to map this state list to
+          type: integer
+          format: int64
+        states:
+          description: List of the time graph entry states associated to this entry and zoom level.
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeGraphState'
+    TimeGraphArrow:
+      type: object
+      properties:
+        start:
+          description: start time for this arrow
+          type: integer
+          format: int64
+        end:
+          description: end time for this arrow
+          type: integer
+          format: int64
+        sourceId:
+          description: Source entry's unique ID
+          type: integer
+          format: int64
+        targetId:
+          description: Target entry's unique ID
+          type: integer
+          format: int64
+        cssId:
+          description: optional ID to refer to the css to format this arrow
+          type: integer
+          format: int32
+    Filter:
+      type: object
+      properties:
+        id:
+          description: Unique id to identify this entry in the backend.
+          type: integer
+          format: int32
+        name:
+          description: Human readable label for this filter
+          type: string
+        filterType:
+          description: Type of the filter
+          type: string
+          enum: [query, expression]
+        start:
+          description: start time for this filter
+          type: integer
+          format: int64
+        end:
+          description: end time for this filter
+          type: integer
+          format: int64
+        query:
+          description: query object
+          type: object
+        expression:
+          description: expression from the filter language
+          type: string
+        


### PR DESCRIPTION
- TimeGraph, XY and Events Table now have unique entry point
- Each entrypoint uses the right entry model
- Modify the table tag (Virtual tables now)
- Migrate to openapi 3.0.0
- Add filter entry point
- Use filter ID in query

Signed-off-by: Simon Delisle <simon.delisle@ericsson.com>