### PR TITLE
Use a newer version of ReDoc to support OpenAPI 3.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@
   </head>
   <body>
     <redoc spec-url='https://raw.githubusercontent.com/theia-ide/trace-server-protocol/master/API.yaml'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Moving to their alpha release in order to support openAPI 3.0

Signed-off-by: Simon Delisle <simon.delisle@ericsson.com>