### PR TITLE
Rename id to entryId in TimeGraphRow model schema

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -1723,7 +1723,7 @@ components:
     TimeGraphRow:
       type: object
       properties:
-        id:
+        entryId:
           description: The entry to map this state list to
           type: integer
           format: int64


### PR DESCRIPTION
The fields named 'id' should represent the object's self unique IDs to
talk between backend and frontend. If the 'id' maps to objects, it
should be named accordingly with the object in question. Here, maps to
entry's ID.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>