### PR TITLE
Add the data type to the axis description

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -1677,8 +1677,17 @@ components:
           description: Label to apply to the axis
           type: string
         unit:
-          description: Type of units used for this axis
+          description: The units used for this axis, to be appended to the data
           type: string
+        dataType:
+          description: Type of data this series represents. Gives a hint on the formatting to give to the data
+          type: string
+          enum:
+            - NUMBER
+            - BINARY_NUMBER
+            - TIMESTAMP
+            - DURATION
+            - STRING
     TimeGraphModel:
       type: object
       properties:


### PR DESCRIPTION
The data type allows clients to know how to format the numerical data,
while the units is just a string to append to the data.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>