### PR TITLE
Augmented APIs for tree models used in various data provider types

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -1672,6 +1672,9 @@ components:
         name:
           description: Displayed name for this header
           type: string
+        tooltip:
+          description: Displayed tooltip for this header. Optional, no tooltip is applied if absent.
+          type: string
       required:
         - name
     XYModel:
@@ -1903,8 +1906,8 @@ components:
       description: Base entry returned by tree endpoints
       type: object
       properties:
-        name:
-          description: Displayed name for this Entry
+        labels:
+          description: Array of cell labels to be displayed. The length of the array and the index of each column need to correspond to the header array returned in the tree model.
           type: array
           items:
             type: string
@@ -1923,6 +1926,7 @@ components:
         style:
           $ref: '#/components/schemas/OutputElementStyle'
       required:
+        - labels
         - id
         - parentId
     EntryModel:

--- a/API.yaml
+++ b/API.yaml
@@ -33,6 +33,8 @@ tags:
   description: How to manage experiments on your server, an experiment represent a collection of traces, which can produce output models.
 - name: Bookmarks
   description: How to bookmark areas of interest in the trace.
+- name: Data Tree
+  description: Learn about querying generic data tree models
 - name: XY
   description: Learn about querying XY models
 - name: TimeGraph
@@ -531,6 +533,56 @@ paths:
             application/json:
               schema:
                 type: string
+  /experiments/{expUUID}/outputs/data/{outputID}/tree:
+    post:
+      tags:
+      - Data Tree
+      summary: API to get a data tree.
+      description: Unique entry point for output providers,
+        to get the tree of visible entries
+      operationId: getDataTeeEntry
+      parameters:
+      - name: expUUID
+        in: path
+        description: UUID of the experiment to query
+        required: true
+        schema:
+          type : integer
+          format: int128
+      - name: outputID
+        in: path
+        description: ID of the output provider to query
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Query parameters to fetch the data tree.
+          Usually contains these parameters, but not limited to
+          - startTime
+          - endTime
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Query'
+      responses:
+        200:
+          description: Returns a list of data tree entries. The returned model must be consistent, parentIds must refer to a parent which exists in the model.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/GenericResponse'
+                  - type: object
+                    properties:
+                      model:
+                        $ref: '#/components/schemas/EntryModel'
+        404:
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/XY/{outputID}/tree:
     post:
       tags:
@@ -556,8 +608,6 @@ paths:
       requestBody:
         description: Query parameters to fetch the XY tree.
           Usually contains these parameters, but not limited to
-          - lowIndex, starting index for the tree
-          - size, number of entries to return
           - startTime
           - endTime
         required: true
@@ -718,8 +768,6 @@ paths:
       requestBody:
         description: Query parameters to fetch the timegraph tree.
           Usually contains these parameters, but not limited to
-          - lowIndex, starting index for the tree
-          - size, number of entries to return
           - startTime
           - endTime
         required: true
@@ -1532,12 +1580,13 @@ components:
           description: Describe the output provider's features
           type: string
         outputType:
-          description: Type of data returned by this output. Serve as a hint to determine what kind of view should be use for this output (ex. XY, Time Graph, Table, etc..). Providers of type TREE_TIME_XY and TIME_GRAPH can be grouped under the same time axis.
+          description: Type of data returned by this output. Serve as a hint to determine what kind of view should be use for this output (ex. XY, Time Graph, Table, etc..). Providers of type TREE_TIME_XY and TIME_GRAPH can be grouped under the same time axis. Providers of type DATA_TREE only provide a tree with columns and don't have any XY nor time graph data associated with.
           type: string
           enum:
             - TABLE
             - TREE_TIME_XY
             - TIME_GRAPH
+            - DATA_TREE
         queryParameters:
           description: List all the possible paramaters that can be use to query this output.
           type: object


### PR DESCRIPTION
The update is to augment the API fro tree models used in various data providers (XY, Time Graph and Data Tree). This allows us to provide header information (name and tooltip) as well as the label strings for each column of each entry if the corresponding tree has columns. The trace server provides the labels formatted string to simplify the client implementation. In later updates, we can add an API to request the raw data that can provide additional details for the client.