### PR TITLE
TimeGraphEntry: the parentId should be optional

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -1928,7 +1928,6 @@ components:
       required:
         - labels
         - id
-        - parentId
     EntryModel:
       type: object
       properties:


### PR DESCRIPTION
The description says the parentId is optional if the entry does not have
a parent.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>