### PR TITLE
Add data type hints to column and entry descriptions

### DIFF
--- a/API.yaml
+++ b/API.yaml
@@ -1871,31 +1871,47 @@ components:
           description: Tags for the entire line
           type: integer
           format: int32
+    DataType:
+      type: object
+      properties:
+        unit:
+          description: The units used for this data, to be appended to the data
+          type: string
+        dataType:
+          description: Type of data a value represents. Gives a hint on the formatting to give to the data
+          type: string
+          enum:
+            - NUMBER
+            - BINARY_NUMBER
+            - TIMESTAMP
+            - DURATION
+            - STRING
     ColumnHeaderEntry:
-      type: object
-      properties:
-        id:
-          description: Unique id to identify this column in the backend.
-          type: integer
-          format: int32
-        name:
-          description: Displayed name for this column
-          type: string
-        description:
-          description: Description of the column
-          type: string
-        type:
-          description: Type of data associated to this column
-          type: string
+      allOf:
+        - type: object
+          properties:
+            id:
+              description: Unique id to identify this column in the backend.
+              type: integer
+              format: int32
+            name:
+              description: Displayed name for this column
+              type: string
+            description:
+              description: Description of the column
+              type: string
+        - $ref: '#/components/schemas/DataType'
     EntryHeader:
-      type: object
-      properties:
-        name:
-          description: Displayed name for this header
-          type: string
-        tooltip:
-          description: Displayed tooltip for this header. Optional, no tooltip is applied if absent.
-          type: string
+      allOf:
+        - type: object
+          properties:
+            name:
+              description: Displayed name for this header
+              type: string
+            tooltip:
+              description: Displayed tooltip for this header. Optional, no tooltip is applied if absent.
+              type: string
+        - $ref: '#/components/schemas/DataType'
       required:
         - name
     XYModel:
@@ -1954,23 +1970,13 @@ components:
         - xValues
         - yValues
     XYAxis:
-      type: object
-      properties:
-        label:
-          description: Label to apply to the axis
-          type: string
-        unit:
-          description: The units used for this axis, to be appended to the data
-          type: string
-        dataType:
-          description: Type of data this series represents. Gives a hint on the formatting to give to the data
-          type: string
-          enum:
-            - NUMBER
-            - BINARY_NUMBER
-            - TIMESTAMP
-            - DURATION
-            - STRING
+      allOf:
+        - type: object
+          properties:
+            label:
+              description: Label to apply to the axis
+              type: string
+        - $ref: '#/components/schemas/DataType'
     TimeGraphModel:
       type: object
       properties:


### PR DESCRIPTION
Fixes #35

With this, it is expected that column and entry descriptions may contain
an optional typing option, to explain what the data type is and, if
available, what unit to use when formatting it.

This allow the server implementations to send raw data to the client,
who would then have the option to format the data, but also the
possibility to do some other actions, like sorting, or use the data for
richer data interactions, as raw data may have a same meaning in
different outputs, unlike pre-formatted data which may not allow such
interaction.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>