### PR TITLE
Add a swagger/index for server's openapi.yaml TSP

### DIFF
--- a/swagger/index.html
+++ b/swagger/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Trace Server Protocol</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='https://raw.githubusercontent.com/theia-ide/trace-server-protocol/master/openapi.yaml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>


### PR DESCRIPTION
This change is the companion of the master branch commit that introduces
openapi.yaml as the alternate TSP version. This is the TSP documented by
Swagger now supported directly in trace-server. As explained in that
master commit's message, these alternate GH pages for TSP show the true
endpoints currently implemented in server. There is that plan to further
align the former manual API.yaml with this generated openapi.yaml,
step-wise.

The master branch with that companion commit is to be merged in this
branch, as usual. That merge should bring the companion openapi.yaml
file and README instructions along.

Fixes #61 partially as first steps.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>