### PR TITLE
Add swagger-core server annotations doc to openapi

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -63,54 +63,87 @@ paths:
     get:
       tags:
       - Annotations
+      summary: API to get annotation categories associated to this experiment and
+        output
       operationId: getAnnotationCategories
       parameters:
       - name: expUUID
         in: path
+        description: The UUID of the experiment in the server
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: The name of the output provider to query
         required: true
         schema:
           type: string
       - name: markerSetId
         in: query
+        description: The optional requested marker set's id
         schema:
           type: string
       responses:
-        default:
-          description: default response
+        "200":
+          description: Annotation categories
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IAnnotationCategoriesResponse'
     post:
       tags:
       - Annotations
+      summary: API to get the annotations associated to this experiment and output
       operationId: getAnnotations
       parameters:
       - name: expUUID
         in: path
+        description: The UUID of the experiment in the server
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: The name of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: "Query parameters to fetch the annotations. The array 'requested_times'\
+          \ is the explicit array of requested sample times. The array 'requested_items'\
+          \ is the list of entryId being requested. The string 'requested_marker_set'\
+          \ is the optional requested marker set's id. The array 'requested_marker_categories'\
+          \ is the list of requested annotation categories; if absent, all annotations\
+          \ are returned."
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/IQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111200000
+                - 111300000
+                - 111400000
+                - 111500000
+                requested_items:
+                - 1
+                - 2
+                requested_marker_set: markerSetId
+                requested_marker_categories:
+                - category1
+                - category2
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: Annotation
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IAnnotationResponse'
   /experiments/{expUUID}/outputs/timeGraph/{outputId}/arrows:
     post:
       tags:
@@ -196,19 +229,23 @@ paths:
     get:
       tags:
       - Annotations
+      summary: API to get marker sets available for this experiment
       operationId: getMarkerSets
       parameters:
       - name: expUUID
         in: path
+        description: The UUID of the experiment in the server
         required: true
         schema:
           type: string
           format: uuid
       responses:
-        default:
-          description: default response
+        "200":
+          description: List of marker sets
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IMarkerSetsResponse'
   /experiments/{expUUID}/outputs/{outputId}:
     get:
       tags:
@@ -708,23 +745,131 @@ paths:
             '*/*': {}
 components:
   schemas:
+    IAnnotationCategoriesModel:
+      type: object
+      properties:
+        annotationCategories:
+          type: array
+          description: Array of all the categories
+          items:
+            type: string
+      description: Model returned by outputs that contains annotation categories available
+        for this output
+    IAnnotationCategoriesResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/IAnnotationCategoriesModel'
+    IGenericResponse:
+      type: object
+      properties:
+        statusMessage:
+          type: string
+        status:
+          type: string
+          description: All possible statuses for a server response
+          enum:
+          - RUNNING
+          - COMPLETED
+          - FAILED
+          - CANCELLED
+      description: Response that includes the status and a status message
+    IAnnotation:
+      required:
+      - duration
+      - entryId
+      - time
+      - type
+      type: object
+      properties:
+        entryId:
+          type: integer
+          description: Entry's unique ID or -1 if annotation not associated with an
+            entry
+          format: int64
+        style:
+          $ref: '#/components/schemas/IOutputElementStyle'
+        label:
+          type: string
+          description: Text label of this annotation
+        type:
+          type: string
+          description: Type of annotation indicating its location
+          enum:
+          - CHART
+          - TREE
+        duration:
+          type: integer
+          description: Duration of this annotation
+          format: int64
+        time:
+          type: integer
+          description: Time of this annotation
+          format: int64
+      description: An annotation is used to mark an interesting area at a given time
+        or time range
+    IAnnotationModel:
+      type: object
+      properties:
+        annotations:
+          type: object
+          additionalProperties:
+            type: array
+            description: Map of annotations where the keys are categories
+            items:
+              $ref: '#/components/schemas/IAnnotation'
+          description: Map of annotations where the keys are categories
+      description: Model returned by outputs that contains annotations per category
+    IAnnotationResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/IAnnotationModel'
+    IOutputElementStyle:
+      type: object
+      properties:
+        parentKey:
+          type: string
+          description: "Parent style key or empty if there is no parent. The parent\
+            \ key should match a style key defined in the style model and is used\
+            \ for style inheritance. A comma-delimited list of parent style keys can\
+            \ be used for style composition, the last one taking precedence."
+        styleValues:
+          type: object
+          additionalProperties:
+            type: object
+            description: Style values or empty map if there are no values. Keys and
+              values are defined in https://git.eclipse.org/r/plugins/gitiles/tracecompass/org.eclipse.tracecompass/+/refs/heads/master/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java
+          description: Style values or empty map if there are no values. Keys and
+            values are defined in https://git.eclipse.org/r/plugins/gitiles/tracecompass/org.eclipse.tracecompass/+/refs/heads/master/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java
+      description: "Represents the style on an element (ex. Entry, TimeGraphState,\
+        \ ...) returned by any output. Supports style inheritance. To avoid having\
+        \ too many styles, the element style can have a parent style and will have\
+        \ all the same style property values as the parent, and can add or override\
+        \ style properties."
     Filter:
       type: object
       properties:
-        expression:
-          type: string
-        name:
-          type: string
-        id:
-          type: integer
-          format: int64
-        tags:
-          type: integer
-          format: int32
         startTime:
           type: integer
           format: int64
+        expression:
+          type: string
+        tags:
+          type: integer
+          format: int32
         endTime:
+          type: integer
+          format: int64
+        name:
+          type: string
+        id:
           type: integer
           format: int64
     QueryParameters:
@@ -738,3 +883,52 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Filter'
+    IParameters:
+      required:
+      - requested_times
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+        requested_items:
+          type: array
+          items:
+            type: integer
+            format: int32
+        requested_marker_set:
+          type: string
+        requested_marker_categories:
+          type: array
+          items:
+            type: string
+    IQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/IParameters'
+    IMarkerSet:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of this marker set
+        id:
+          type: string
+          description: ID of this marker set
+      description: A marker set is used to represent a set of annotations that can
+        be fetched
+    IMarkerSetsResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            type: array
+            items:
+              $ref: '#/components/schemas/IMarkerSet'


### PR DESCRIPTION
This change brings trace-server's [1] version of the TSP OpenApi herein.
It is therefore a continuation of [2]'s WIP. Reference [2] already
explains the context and usage of the hereby changed openapi.yaml file.

Contributes to fixing #61 partially as another incremental step.

[1] https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/187795
[2] https://github.com/theia-ide/trace-server-protocol#alternate-tsp-version

Signed-off-by: Marco Miller <marco.miller@ericsson.com>

- This PR is replacing the recently obsoleted #64 one, now using a topic branch instead.
- This is to allow for follow-up PRs, about adding other Swagger documentation scopes next.