### PR TITLE
Update openapi.yaml with latest swagger-core documentation from server

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -698,59 +698,88 @@ paths:
     get:
       tags:
       - Experiments
+      summary: Get the model object for an experiment
       operationId: getExperiment
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       responses:
-        default:
-          description: default response
+        "200":
+          description: Return the experiment model
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IExperiment'
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
     delete:
       tags:
       - Experiments
+      summary: Remove an experiment from the server
       operationId: deleteExperiment
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       responses:
-        default:
-          description: default response
+        "200":
+          description: "The trace was successfully deleted, return the deleted experiment."
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IExperiment'
+        "404":
+          description: No such experiment
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments:
     get:
       tags:
       - Experiments
+      summary: Get the list of experiments on the server
       operationId: getExperiments
       responses:
-        default:
-          description: default response
+        "200":
+          description: Returns a list of experiments
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IExperiment'
     post:
       tags:
       - Experiments
+      summary: Create a new experiment on the server
       operationId: postExperiment
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/IExperimentQueryParameters'
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: The experiment was successfully created
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IExperiment'
   /health:
     get:
       tags:
@@ -1606,3 +1635,85 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/ITreeEntryModel'
+    IExperiment:
+      type: object
+      properties:
+        nbEvents:
+          type: integer
+          description: Current number of indexed events in the experiment
+          format: int64
+        indexingStatus:
+          type: string
+          description: Status of the experiment indexing
+          enum:
+          - RUNNING
+          - COMPLETED
+          - CLOSED
+        traces:
+          type: array
+          description: The traces encapsulated by this experiment
+          items:
+            $ref: '#/components/schemas/ITrace'
+        start:
+          type: integer
+          description: The experiment's start time
+          format: int64
+        end:
+          type: integer
+          description: The experiment's end time
+          format: int64
+        name:
+          type: string
+          description: User defined name for the experiment
+        UUID:
+          type: string
+          description: The experiment's unique identifier
+          format: uuid
+    ITrace:
+      type: object
+      properties:
+        nbEvents:
+          type: integer
+          description: Current number of indexed events in the trace
+          format: int64
+        indexingStatus:
+          type: string
+          description: Status of the trace indexing
+          enum:
+          - RUNNING
+          - COMPLETED
+          - CLOSED
+        start:
+          type: integer
+          description: The trace's start time
+          format: int64
+        end:
+          type: integer
+          description: The trace's end time
+          format: int64
+        name:
+          type: string
+          description: User defined name for the trace
+        path:
+          type: string
+          description: Path to the trace on the server's file system
+        UUID:
+          type: string
+          description: The trace's unique identifier
+          format: uuid
+    IExperimentQueryParameters:
+      required:
+      - name
+      - traces
+      type: object
+      properties:
+        traces:
+          type: array
+          description: The unique identifiers of the traces to encapsulate in this
+            experiment
+          items:
+            type: string
+            format: uuid
+        name:
+          type: string
+          description: The name to give this experiment

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -648,29 +648,52 @@ paths:
     post:
       tags:
       - XY
+      summary: API to get the XY tree
+      description: "Unique entry point for output providers, to get the tree of visible\
+        \ entries"
       operationId: getXYTree
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: "Query parameters to fetch the XY tree. When 'requested_times'\
+          \ is absent the tree for the full range is returned. When present it specifies\
+          \ a range as [start, end]."
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/ITreeQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111111111
+                - 222222222
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: "Returns a list of XY entries. The returned model must be consistent,\
+            \ parentIds must refer to a parent which exists in the model."
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IXYTreeResponse'
+        "404":
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}:
     get:
       tags:
@@ -1575,3 +1598,11 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/IXYModel'
+    IXYTreeResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/ITreeEntryModel'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -46,8 +46,6 @@ tags:
   description: How to manage physical traces on your server.
 - name: Virtual Tables
   description: Learn about querying virtual table models (e.g. Events Table).
-- name: XML
-  description: Learn about querying XML analyses.
 - name: XY
   description: Learn about querying XY models.
 paths:
@@ -908,66 +906,6 @@ paths:
             application/json:
               schema:
                 type: string
-  /xml/{name}:
-    delete:
-      tags:
-      - XML
-      operationId: deleteXml
-      parameters:
-      - name: name
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-  /xml:
-    get:
-      tags:
-      - XML
-      operationId: getXml
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-    put:
-      tags:
-      - XML
-      operationId: putXml
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              type: object
-              properties:
-                path:
-                  type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
-    post:
-      tags:
-      - XML
-      operationId: postXml
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              type: object
-              properties:
-                path:
-                  type: string
-      responses:
-        default:
-          description: default response
-          content:
-            '*/*': {}
 components:
   schemas:
     IAnnotationCategoriesModel:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -784,12 +784,18 @@ paths:
     get:
       tags:
       - Diagnostic
+      summary: Get the health status of this server
       operationId: getHealthStatus
       responses:
-        default:
-          description: default response
+        "200":
+          description: The trace server is running and ready to receive requests
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IServerStatus'
+        "503":
+          description: The trace server is unavailable or in maintenance and cannot
+            receive requests
   /traces/{uuid}:
     get:
       tags:
@@ -1717,3 +1723,11 @@ components:
         name:
           type: string
           description: The name to give this experiment
+    IServerStatus:
+      type: object
+      properties:
+        status:
+          type: string
+          description: The status of the server
+          enum:
+          - UP

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -454,29 +454,39 @@ paths:
     post:
       tags:
       - Styles
+      summary: API to get the style map associated to this experiment and output
       operationId: getStyles
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: Query parameters to fetch the style map
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/IStylesQueryParameters'
+            example:
+              parameters: {}
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: Style model that can be used jointly with OutputElementStyle
+            to retrieve specific style values
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IStylesResponse'
   /experiments/{expUUID}/outputs/timeGraph/{outputId}/tooltip:
     post:
       tags:
@@ -1413,6 +1423,32 @@ components:
       properties:
         parameters:
           $ref: '#/components/schemas/IStatesParameters'
+    IOutputStyleModel:
+      type: object
+      properties:
+        styles:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/IOutputElementStyle'
+      description: Map of styles specific to an output where values give hints on
+        the style. The keys are strings that can be used in OutputElementStyle
+    IStylesResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/IOutputStyleModel'
+    IStylesParameters:
+      type: object
+    IStylesQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/IStylesParameters'
     ITimeGraphTooltip:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -596,29 +596,62 @@ paths:
     post:
       tags:
       - XY
+      summary: API to get the XY model
+      description: "Unique endpoint for all xy models, ensures that the same template\
+        \ is followed for all endpoints."
       operationId: getXY
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: Query parameters to fetch the XY model. The array 'requested_times'
+          is the explicit array of requested sample times. The array 'requested_items'
+          is the list of entryId or seriesId being requested.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/IXYQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111200000
+                - 111300000
+                - 111400000
+                - 111500000
+                requested_items:
+                - 1
+                - 2
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: Return the queried XYResponse
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IXYResponse'
+        "404":
+          description: No such trace
+          content:
+            application/json:
+              schema:
+                type: string
+        "405":
+          description: Analysis not possible for this trace
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/XY/{outputId}/tooltip:
     get:
       tags:
@@ -1623,3 +1656,74 @@ components:
       properties:
         parameters:
           $ref: '#/components/schemas/ITreeParameters'
+    ISeriesModel:
+      required:
+      - seriesId
+      - seriesName
+      - xValues
+      - yValues
+      type: object
+      properties:
+        seriesId:
+          type: integer
+          description: Series' ID
+          format: int64
+        seriesName:
+          type: string
+          description: Series' name
+        xValues:
+          type: array
+          description: Series' X values
+          items:
+            type: integer
+            format: int64
+        yValues:
+          type: array
+          description: Series' Y values
+          items:
+            type: integer
+            format: int64
+    IXYModel:
+      required:
+      - series
+      - title
+      type: object
+      properties:
+        series:
+          type: array
+          items:
+            $ref: '#/components/schemas/ISeriesModel'
+        title:
+          type: string
+          description: Title of the model
+    IXYResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/IXYModel'
+    IXYParameters:
+      required:
+      - requested_items
+      - requested_times
+      type: object
+      properties:
+        requested_items:
+          type: array
+          items:
+            type: integer
+            format: int32
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+    IXYQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/IXYParameters'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -400,29 +400,56 @@ paths:
     post:
       tags:
       - TimeGraph
+      summary: API to get the Time Graph states
+      description: "Unique entry point for all TimeGraph states, ensures that the\
+        \ same template is followed for all views"
       operationId: getStates
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: Query parameters to fetch the timegraph states. The array 'requested_times'
+          is the explicit array of requested sample times. The array 'requested_items'
+          is the list of entryId being requested.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/IStatesQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111200000
+                - 111300000
+                - 111400000
+                - 111500000
+                requested_items:
+                - 1
+                - 2
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: Returns a list of time graph rows
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITimeGraphStatesResponse'
+        "404":
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/{outputId}/style:
     post:
       tags:
@@ -454,29 +481,56 @@ paths:
     post:
       tags:
       - TimeGraph
+      summary: API to get a Time Graph tooltip
+      description: Endpoint to retrieve tooltips for time graph
       operationId: getTimeGraphTooltip
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: Query parameters to fetch the timegraph tooltip. The array 'requested_times'
+          is an array with a single timestamp. The array 'requested_items' is an array
+          with a single entryId being requested.  The object 'requested_element' is
+          the element for which the tooltip is requested.
         content:
-          '*/*':
+          application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/ITooltipQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111200000
+                requested_items:
+                - 1
+                requested_element:
+                  elementType: state
+                  time: 111100000
+                  duration: 100000
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: Returns a list of tooltip keys to values
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITimeGraphTooltipResponse'
+        "404":
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/timeGraph/{outputId}/tree:
     post:
       tags:
@@ -1256,3 +1310,156 @@ components:
           - TREE_TIME_XY
           - TIME_GRAPH
           - DATA_TREE
+    ITimeGraphModel:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ITimeGraphRowModel'
+    ITimeGraphRowModel:
+      required:
+      - entryId
+      - states
+      type: object
+      properties:
+        states:
+          type: array
+          description: List of the time graph entry states associated to this entry
+            and zoom level
+          items:
+            $ref: '#/components/schemas/ITimeGraphState'
+        entryId:
+          type: integer
+          description: The entry to map this state list to
+          format: int64
+    ITimeGraphState:
+      required:
+      - end
+      - start
+      type: object
+      properties:
+        label:
+          type: string
+          description: "Text label to apply to this TimeGraphState if resolution permits.\
+            \ Optional, no label is applied if absent"
+        tags:
+          type: integer
+          description: Tags to apply on this state. A value of 0 should be handled
+            as none (no tags)
+          format: int32
+        style:
+          $ref: '#/components/schemas/IOutputElementStyle'
+        start:
+          type: integer
+          description: Start time for this state
+          format: int64
+        end:
+          type: integer
+          description: End time for this state
+          format: int64
+    ITimeGraphStatesResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/ITimeGraphModel'
+    IStatesParameters:
+      required:
+      - requested_items
+      - requested_times
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+        requested_items:
+          type: array
+          items:
+            type: integer
+            format: int32
+    IStatesQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/IStatesParameters'
+    ITimeGraphTooltip:
+      type: object
+      properties:
+        value:
+          type: string
+        key:
+          type: string
+    ITimeGraphTooltipResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            type: array
+            items:
+              $ref: '#/components/schemas/ITimeGraphTooltip'
+    IElement:
+      required:
+      - duration
+      - elementType
+      - time
+      type: object
+      properties:
+        destinationId:
+          type: integer
+          description: Destination entry's unique ID (arrow)
+          format: int64
+        entryId:
+          type: integer
+          description: "Entry's unique ID (annotation, arrow)"
+          format: int64
+        time:
+          type: integer
+          description: Element's start time
+          format: int64
+        elementType:
+          type: string
+          description: The type of element
+          enum:
+          - STATE
+          - ANNOTATION
+          - ARROW
+        duration:
+          type: integer
+          description: Element's duration
+          format: int64
+      description: An element model to be identified
+    ITooltipParameters:
+      required:
+      - requested_element
+      - requested_items
+      - requested_times
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+        requested_items:
+          type: array
+          items:
+            type: integer
+            format: int32
+        requested_element:
+          $ref: '#/components/schemas/IElement'
+    ITooltipQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/ITooltipParameters'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,19 +33,11 @@ servers:
 tags:
 - name: Annotations
   description: Retrieve annotations for different outputs.
-- name: Bookmarks
-  description: How to bookmark areas of interest in the trace.
 - name: Diagnostic
   description: Refer to the server's status.
-- name: Data Tree
-  description: Learn about querying generic data tree models.
 - name: Experiments
   description: "How to manage experiments on your server; an experiment represents\
     \ a collection of traces, which can produce output models."
-- name: Features
-  description: Discover the features which are available on a given server.
-- name: Filters
-  description: How to filter and query.
 - name: Styles
   description: Retrieve styles for different outputs.
 - name: TimeGraph
@@ -652,43 +644,6 @@ paths:
             application/json:
               schema:
                 type: string
-  /experiments/{expUUID}/outputs/XY/{outputId}/tooltip:
-    get:
-      tags:
-      - XY
-      operationId: getXYTooltip
-      parameters:
-      - name: expUUID
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: outputId
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: xValue
-        in: query
-        schema:
-          type: integer
-          format: int64
-      - name: yValue
-        in: query
-        schema:
-          type: integer
-          format: int64
-      - name: entryId
-        in: query
-        schema:
-          type: integer
-          format: int64
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /experiments/{expUUID}/outputs/XY/{outputId}/tree:
     post:
       tags:
@@ -768,81 +723,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/QueryParameters'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /filters:
-    get:
-      tags:
-      - Filters
-      operationId: getFilters
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-    post:
-      tags:
-      - Filters
-      operationId: createFilter
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /filters/{filterId}:
-    get:
-      tags:
-      - Filters
-      operationId: getFilter
-      parameters:
-      - name: filterId
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-    put:
-      tags:
-      - Filters
-      operationId: updateFilter
-      parameters:
-      - name: filterId
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-    delete:
-      tags:
-      - Filters
-      operationId: deleteFilter
-      parameters:
-      - name: filterId
-        in: path
-        required: true
-        schema:
-          type: string
       responses:
         default:
           description: default response

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -220,7 +220,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IColumnsQueryParameters'
+              $ref: '#/components/schemas/IOptionalQueryParameters'
             example:
               parameters: {}
         required: true
@@ -425,7 +425,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IStatesQueryParameters'
+              $ref: '#/components/schemas/IRequestedQueryParameters'
             example:
               parameters:
                 requested_times:
@@ -475,7 +475,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IStylesQueryParameters'
+              $ref: '#/components/schemas/IOptionalQueryParameters'
             example:
               parameters: {}
         required: true
@@ -621,7 +621,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IXYQueryParameters'
+              $ref: '#/components/schemas/IRequestedQueryParameters'
             example:
               parameters:
                 requested_times:
@@ -1222,15 +1222,15 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/ITableColumnHeader'
-    IColumnsParameters:
+    IOptionalParameters:
       type: object
-    IColumnsQueryParameters:
+    IOptionalQueryParameters:
       required:
       - parameters
       type: object
       properties:
         parameters:
-          $ref: '#/components/schemas/IColumnsParameters'
+          $ref: '#/components/schemas/IOptionalParameters'
     IVirtualTableCell:
       type: object
       properties:
@@ -1433,7 +1433,7 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/ITimeGraphModel'
-    IStatesParameters:
+    IRequestedParameters:
       required:
       - requested_items
       - requested_times
@@ -1449,13 +1449,13 @@ components:
           items:
             type: integer
             format: int32
-    IStatesQueryParameters:
+    IRequestedQueryParameters:
       required:
       - parameters
       type: object
       properties:
         parameters:
-          $ref: '#/components/schemas/IStatesParameters'
+          $ref: '#/components/schemas/IRequestedParameters'
     IOutputStyleModel:
       type: object
       properties:
@@ -1473,15 +1473,6 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/IOutputStyleModel'
-    IStylesParameters:
-      type: object
-    IStylesQueryParameters:
-      required:
-      - parameters
-      type: object
-      properties:
-        parameters:
-          $ref: '#/components/schemas/IStylesParameters'
     ITimeGraphTooltip:
       type: object
       properties:
@@ -1704,26 +1695,3 @@ components:
         properties:
           model:
             $ref: '#/components/schemas/IXYModel'
-    IXYParameters:
-      required:
-      - requested_items
-      - requested_times
-      type: object
-      properties:
-        requested_items:
-          type: array
-          items:
-            type: integer
-            format: int32
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
-    IXYQueryParameters:
-      required:
-      - parameters
-      type: object
-      properties:
-        parameters:
-          $ref: '#/components/schemas/IXYParameters'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -800,59 +800,114 @@ paths:
     get:
       tags:
       - Traces
+      summary: Get the model object for a trace
       operationId: getTrace
       parameters:
       - name: uuid
         in: path
+        description: UUID of the trace to query
         required: true
         schema:
           type: string
           format: uuid
       responses:
-        default:
-          description: default response
+        "200":
+          description: Return the trace model
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITrace'
+        "404":
+          description: No such trace
+          content:
+            application/json:
+              schema:
+                type: string
     delete:
       tags:
       - Traces
+      summary: Remove a trace from the server and disk
       operationId: deleteTrace
       parameters:
       - name: uuid
         in: path
+        description: UUID of the trace to query
         required: true
         schema:
           type: string
           format: uuid
       responses:
-        default:
-          description: default response
+        "200":
+          description: The trace was successfully deleted
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITrace'
+        "404":
+          description: No such trace
+          content:
+            application/json:
+              schema:
+                type: string
   /traces:
     get:
       tags:
       - Traces
+      summary: Get the list of physical traces imported on the server
       operationId: getTraces
       responses:
-        default:
-          description: default response
+        "200":
+          description: Returns a list of traces
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ITrace'
     post:
       tags:
       - Traces
+      summary: Import a trace
+      description: Import a trace to the trace server. Return some base information
+        once imported.
       operationId: putTrace
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/ITraceQueryParameters'
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: The trace has been successfully added to the trace server
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITrace'
+        "404":
+          description: No such trace
+          content:
+            application/json:
+              schema:
+                type: string
+        "406":
+          description: Cannot read this trace type
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: There was already a trace with this name
+          content:
+            application/json:
+              schema:
+                type: string
+        "501":
+          description: Trace type not supported
+          content:
+            application/json:
+              schema:
+                type: string
   /xml/{name}:
     delete:
       tags:
@@ -1731,3 +1786,19 @@ components:
           description: The status of the server
           enum:
           - UP
+    ITraceQueryParameters:
+      required:
+      - URI
+      type: object
+      properties:
+        typeID:
+          type: string
+          description: "The trace type's ID, to force the use of a parser / disambiguate\
+            \ the trace type"
+        name:
+          type: string
+          description: "The name of the trace in the server, to override the default\
+            \ name"
+        URI:
+          type: string
+          description: URI of the trace

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -535,29 +535,53 @@ paths:
     post:
       tags:
       - TimeGraph
+      summary: API to get the Time Graph tree
+      description: "Unique entry point for output providers, to get the tree of visible\
+        \ entries"
       operationId: getTimeGraphTree
       parameters:
       - name: expUUID
         in: path
+        description: UUID of the experiment to query
         required: true
         schema:
           type: string
           format: uuid
       - name: outputId
         in: path
+        description: ID of the output provider to query
         required: true
         schema:
           type: string
       requestBody:
+        description: "Query parameters to fetch the timegraph tree. When 'requested_times'\
+          \ is absent the tree for the full range is returned. When present it specifies\
+          \ a range as [start, end]."
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QueryParameters'
+              $ref: '#/components/schemas/ITreeQueryParameters'
+            example:
+              parameters:
+                requested_times:
+                - 111111111
+                - 222222222
+        required: true
       responses:
-        default:
-          description: default response
+        "200":
+          description: "Returns a list of Time Graph entries. The returned model must\
+            \ be consistent, parentIds must refer to a parent which exists in the\
+            \ model."
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ITimeGraphTreeResponse'
+        "404":
+          description: Experiment or output provider not found
+          content:
+            application/json:
+              schema:
+                type: string
   /experiments/{expUUID}/outputs/XY/{outputId}/xy:
     post:
       tags:
@@ -1463,3 +1487,103 @@ components:
       properties:
         parameters:
           $ref: '#/components/schemas/ITooltipParameters'
+    ITimeGraphEntry:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/ITreeDataModel'
+      - type: object
+        properties:
+          start:
+            type: integer
+            description: Beginning of the range for which this entry exists
+            format: int64
+          end:
+            type: integer
+            description: End of the range for which this entry exists
+            format: int64
+    ITimeGraphTreeModel:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/ITreeEntryModel'
+      - type: object
+        properties:
+          entries:
+            type: array
+            items:
+              $ref: '#/components/schemas/ITimeGraphEntry'
+    ITimeGraphTreeResponse:
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/IGenericResponse'
+      - type: object
+        properties:
+          model:
+            $ref: '#/components/schemas/ITimeGraphTreeModel'
+    ITreeColumnHeader:
+      required:
+      - name
+      type: object
+      properties:
+        tooltip:
+          type: string
+          description: "Displayed tooltip for this header. Optional, no tooltip is\
+            \ applied if absent."
+        name:
+          type: string
+          description: Displayed name for this header
+    ITreeDataModel:
+      required:
+      - id
+      - labels
+      type: object
+      properties:
+        parentId:
+          type: integer
+          description: "Unique id to identify this parent's entry, optional if this\
+            \ entry does not have a parent."
+          format: int64
+        hasData:
+          type: boolean
+          description: Whether or not this entry has data
+        labels:
+          type: array
+          description: Array of cell labels to be displayed. The length of the array
+            and the index of each column need to correspond to the header array returned
+            in the tree model.
+          items:
+            type: string
+        style:
+          $ref: '#/components/schemas/IOutputElementStyle'
+        id:
+          type: integer
+          description: Unique id to identify this entry in the backend
+          format: int64
+      description: Base entry returned by tree endpoints
+    ITreeEntryModel:
+      required:
+      - entries
+      type: object
+      properties:
+        headers:
+          type: array
+          items:
+            $ref: '#/components/schemas/ITreeColumnHeader'
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/ITreeDataModel'
+    ITreeParameters:
+      type: object
+      properties:
+        requested_times:
+          type: array
+          items:
+            type: integer
+            format: int64
+    ITreeQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/ITreeParameters'


### PR DESCRIPTION
This change brings trace-server's [1] version of the TSP OpenApi herein.
It is therefore a continuation of [2]'s WIP.

Contributes to fixing #61 further as yet another incremental step.

[1] https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/189067
[2] https://github.com/theia-ide/trace-server-protocol#alternate-tsp-version

Signed-off-by: Marco Miller <marco.miller@ericsson.com>