### PR TITLE
openapi: Remove leftover QueryParameters few lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In the meantime, Swagger has recently been added to trace-server.
    * Launch with `all workspace and enabled target plug-ins`.
 1. Browse [to here][4] ([swagger][5]) or so to generate server's TSP.
 1. Bring the resulting file over; e.g.: `mv ~/Downloads/openapi.yaml .`
-1. Update the latter with its license information and remove Jersey's WADL: `./openapi.py`
+1. Update the latter with its license information and remove extra information: `./openapi.py`
 1. The resulting git diff may then be pushed for review, at will.
 
 [1] org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core

--- a/openapi.py
+++ b/openapi.py
@@ -35,8 +35,8 @@ UTF8 = "utf-8"
 tmp = open(TEMP, 'w', encoding=UTF8)
 
 # shutil copy didn't work locally on macOS.
-with open(LICS, encoding=UTF8) as license:
-    for line in license:
+with open(LICS, encoding=UTF8) as license_text:
+    for line in license_text:
         tmp.write(line)
 
 wadl = False

--- a/openapi.py
+++ b/openapi.py
@@ -39,6 +39,8 @@ with open(TEMP, 'w', encoding=UTF8) as tmp:
     with open(LICS, encoding=UTF8) as license_text:
         for line in license_text:
             tmp.write(line)
+    FILTER = False
+    QUERY_P = False
     WADL = False
     with open(FILE, encoding=UTF8) as yaml:
         for line in yaml:
@@ -49,6 +51,15 @@ with open(TEMP, 'w', encoding=UTF8) as tmp:
                 # wadl stops if no longer within a wadl path:
                 WADL = not re.match(r'^\S+:$', line)
             if not WADL:
-                tmp.write(line)
+                if QUERY_P:
+                    # previous line was a QueryParameters one, maybe this one is too:
+                    QUERY_P = re.match(r'^\s\s\s\s\s\stype: object$', line)
+                else:
+                    # if QueryParameters lines, will remove these:
+                    QUERY_P = re.match(r'^\s\s\s\sQueryParameters:$', line)
+                # if Filter lines present unexpectedly, cancel QueryParameters removal:
+                FILTER = FILTER or re.match(r'^\s\s\s\sFilter:$', line)
+                if not QUERY_P or FILTER:
+                    tmp.write(line)
 
 os.rename(TEMP, FILE)

--- a/openapi.py
+++ b/openapi.py
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""See ./README.md for how to use this file."""
+
 import os
 import re
 

--- a/openapi.py
+++ b/openapi.py
@@ -34,23 +34,21 @@ TEMP = NAME + ".tmp"
 LICS = NAME + ".license"
 UTF8 = "utf-8"
 
-tmp = open(TEMP, 'w', encoding=UTF8)
-
 # shutil copy didn't work locally on macOS.
-with open(LICS, encoding=UTF8) as license_text:
-    for line in license_text:
-        tmp.write(line)
-
-WADL = False
-with open(FILE, encoding=UTF8) as yaml:
-    for line in yaml:
-        if re.match(r'^\s\s/.+:$', line):
-            # line is a path; check if wadl to remove it:
-            WADL = "application.wadl" in line
-        elif WADL:
-            # wadl stops if no longer within a wadl path:
-            WADL = not re.match(r'^\S+:$', line)
-        if not WADL:
+with open(TEMP, 'w', encoding=UTF8) as tmp:
+    with open(LICS, encoding=UTF8) as license_text:
+        for line in license_text:
             tmp.write(line)
+    WADL = False
+    with open(FILE, encoding=UTF8) as yaml:
+        for line in yaml:
+            if re.match(r'^\s\s/.+:$', line):
+                # line is a path; check if wadl to remove it:
+                WADL = "application.wadl" in line
+            elif WADL:
+                # wadl stops if no longer within a wadl path:
+                WADL = not re.match(r'^\S+:$', line)
+            if not WADL:
+                tmp.write(line)
 
 os.rename(TEMP, FILE)

--- a/openapi.py
+++ b/openapi.py
@@ -41,16 +41,16 @@ with open(LICS, encoding=UTF8) as license_text:
     for line in license_text:
         tmp.write(line)
 
-wadl = False
+WADL = False
 with open(FILE, encoding=UTF8) as yaml:
     for line in yaml:
         if re.match(r'^\s\s/.+:$', line):
             # line is a path; check if wadl to remove it:
-            wadl = "application.wadl" in line
-        elif wadl:
+            WADL = "application.wadl" in line
+        elif WADL:
             # wadl stops if no longer within a wadl path:
-            wadl = not re.match(r'^\S+:$', line)
-        if not wadl:
+            WADL = not re.match(r'^\S+:$', line)
+        if not WADL:
             tmp.write(line)
 
 os.rename(TEMP, FILE)

--- a/openapi.py
+++ b/openapi.py
@@ -30,16 +30,17 @@ NAME = "openapi"
 FILE = NAME + ".yaml"
 TEMP = NAME + ".tmp"
 LICS = NAME + ".license"
+UTF8 = "utf-8"
 
-tmp = open(TEMP, 'w')
+tmp = open(TEMP, 'w', encoding=UTF8)
 
 # shutil copy didn't work locally on macOS.
-with open(LICS) as license:
+with open(LICS, encoding=UTF8) as license:
     for line in license:
         tmp.write(line)
 
 wadl = False
-with open(FILE) as yaml:
+with open(FILE, encoding=UTF8) as yaml:
     for line in yaml:
         if re.match(r'^\s\s/.+:$', line):
             # line is a path; check if wadl to remove it:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1016,36 +1016,6 @@ components:
         \ too many styles, the element style can have a parent style and will have\
         \ all the same style property values as the parent, and can add or override\
         \ style properties."
-    Filter:
-      type: object
-      properties:
-        startTime:
-          type: integer
-          format: int64
-        expression:
-          type: string
-        tags:
-          type: integer
-          format: int32
-        endTime:
-          type: integer
-          format: int64
-        name:
-          type: string
-        id:
-          type: integer
-          format: int64
-    QueryParameters:
-      type: object
-      properties:
-        parameters:
-          type: object
-          additionalProperties:
-            type: object
-        filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/Filter'
     IAnnotationsParameters:
       required:
       - requested_times


### PR DESCRIPTION
Have `openapi.py` remove the only few left-over `QueryParameters` lines from `openapi.yaml`.
- Remove these lines using this python script,
- per `README.md` instructions,
- as companion [1] (`swagger-core`, server) cannot remove them all.
- Include an updated `openapi.yaml` based on this and [1] altogether.

This main (tip) commit includes some more details,
- and is based on pylint fixes as preparation
- (a few more, base commits).

[1] https://git.eclipse.org/r/c/tracecompass.incubator/org.eclipse.tracecompass.incubator/+/189088

Signed-off-by: Marco Miller <marco.miller@ericsson.com>