### PR TITLE
Fix multiple bugs in TSP specification

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -26,7 +26,7 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.3.0
+  version: 0.3.1
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
@@ -2856,11 +2856,8 @@ components:
     TreeParameters:
       type: object
       properties:
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
+        requested_timerange:
+          $ref: '#/components/schemas/TimeRange'
     TreeQueryParameters:
       required:
       - parameters
@@ -3265,8 +3262,8 @@ components:
           type: array
           description: Series' Y values
           items:
-            type: integer
-            format: int64
+            type: number
+            format: double
       description: This model includes the series output style values.
     XYModel:
       required:
@@ -3362,7 +3359,7 @@ components:
           type: string
           description: The trace's unique identifier
           format: uuid
-    ExperimentQueryParameters:
+    ExperimentParameters:
       required:
       - name
       - traces
@@ -3378,6 +3375,13 @@ components:
         name:
           type: string
           description: The name to give this experiment
+    ExperimentQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/ExperimentParameters'
     ServerStatus:
       type: object
       properties:
@@ -3427,7 +3431,7 @@ components:
           type: string
           description: Version in the format Major.Minor.Micro
       description: System Information Response
-    TraceQueryParameters:
+    TraceParameters:
       required:
       - uri
       type: object
@@ -3443,6 +3447,13 @@ components:
         uri:
           type: string
           description: URI of the trace
+    TraceQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/TraceParameters'
     Filter:
       type: object
       properties:

--- a/API.yaml
+++ b/API.yaml
@@ -26,7 +26,7 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.3.0
+  version: 0.3.1
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
@@ -2335,11 +2335,8 @@ components:
     TreeParameters:
       type: object
       properties:
-        requested_times:
-          type: array
-          items:
-            type: integer
-            format: int64
+        requested_timerange:
+          $ref: '#/components/schemas/TimeRange'
     TreeQueryParameters:
       required:
       - parameters
@@ -2744,8 +2741,8 @@ components:
           type: array
           description: Series' Y values
           items:
-            type: integer
-            format: int64
+            type: number
+            format: double
       description: This model includes the series output style values.
     XYModel:
       required:
@@ -2841,7 +2838,7 @@ components:
           type: string
           description: The trace's unique identifier
           format: uuid
-    ExperimentQueryParameters:
+    ExperimentParameters:
       required:
       - name
       - traces
@@ -2857,6 +2854,13 @@ components:
         name:
           type: string
           description: The name to give this experiment
+    ExperimentQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/ExperimentParameters'
     ServerStatus:
       type: object
       properties:
@@ -2906,7 +2910,7 @@ components:
           type: string
           description: Version in the format Major.Minor.Micro
       description: System Information Response
-    TraceQueryParameters:
+    TraceParameters:
       required:
       - uri
       type: object
@@ -2922,3 +2926,10 @@ components:
         uri:
           type: string
           description: URI of the trace
+    TraceQueryParameters:
+      required:
+      - parameters
+      type: object
+      properties:
+        parameters:
+          $ref: '#/components/schemas/TraceParameters'


### PR DESCRIPTION
This PR fixes multiple errors in the TSP specification. See below the list of changes and the corresponding trace server PR for the swagger documentation.

Trace Server PR:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/189

- swagger: Fix TraceQueryParameters and ExperimentQueryParameters Fixes #100
- swagger: Fix type of array of Y values in XY SeriesModel Fixes #101
- Update version

Trace Server PR:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/184

- Fix TreeParameters to use TimeRange instead of array of time samples

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>