### PR TITLE
Fix specification for sampling in xy output

### DIFF
--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -26,7 +26,7 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.5.0
+  version: 0.6.0
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
@@ -2988,6 +2988,7 @@ components:
     TreeColumnHeader:
       required:
       - name
+      - tooltip
       type: object
       properties:
         dataType:
@@ -3136,31 +3137,26 @@ components:
           type: string
           description: "Type of axis domain: 'range'"
       description: Domain of values supported on a numberical range chart axis.
-    Sampling:
+    Range:
+      required:
+      - end
+      - start
       type: object
-      description: Sampling values
-      oneOf:
-      - type: array
-        description: "Sampling as a flat list of timestamps. Example: [100, 200, 350]"
-        items:
+      properties:
+        start:
           type: integer
+          description: Start of the range (inclusive).
           format: int64
-      - type: array
-        description: "Sampling as a flat list of categories. Example: [\"READ\", \"\
-          WRITE\"]"
-        items:
-          type: string
-      - type: array
-        description: "Sampling as a list of start/end range objects. Example: [{\"\
-          start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]"
-        items:
-          $ref: '#/components/schemas/StartEndRange'
+        end:
+          type: integer
+          description: End of the range (inclusive).
+          format: int64
+      description: An object representing a closed interval with a start and end.
     SeriesModel:
       required:
       - seriesId
       - seriesName
       - style
-      - xValues
       - xValuesDescription
       - yValues
       - yValuesDescription
@@ -3176,7 +3172,29 @@ components:
         style:
           $ref: "#/components/schemas/OutputElementStyle"
         xValues:
-          $ref: "#/components/schemas/Sampling"
+          type: array
+          description: "X values as list of int64 values (e.g. timestamps). Example:\
+            \ [100, 200, 350]. Mutually exclusive with xCategories/xRanges."
+          items:
+            type: integer
+            description: "X values as list of int64 values (e.g. timestamps). Example:\
+              \ [100, 200, 350]. Mutually exclusive with xCategories/xRanges."
+            format: int64
+        xCategories:
+          type: array
+          description: "X values as list of category strings. Example: [\"READ\",\
+            \ \"WRITE\"]. Mutually exclusive with xValues/xRanges."
+          items:
+            type: string
+            description: "X values as list of category strings. Example: [\"READ\"\
+              , \"WRITE\"]. Mutually exclusive with xValues/xRanges."
+        xRanges:
+          type: array
+          description: "X values as list of start/end range objects. Example: [{\"\
+            start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]. Mutually exclusive\
+            \ with xValues/xCategories."
+          items:
+            $ref: "#/components/schemas/Range"
         yValues:
           type: array
           description: Series' Y values
@@ -3188,21 +3206,6 @@ components:
         yValuesDescription:
           $ref: "#/components/schemas/XYAxisDescription"
       description: This model includes the series output style values.
-    StartEndRange:
-      required:
-      - end
-      - start
-      type: object
-      properties:
-        start:
-          type: integer
-          description: Start of the range (inclusive).
-          format: int64
-        end:
-          type: integer
-          description: End of the range (inclusive).
-          format: int64
-      description: An object representing a closed interval with a start and end.
     XYAxisDescription:
       required:
       - dataType

--- a/API-proposed.yaml
+++ b/API-proposed.yaml
@@ -3136,34 +3136,25 @@ components:
           type: string
           description: "Type of axis domain: 'range'"
       description: Domain of values supported on a numberical range chart axis.
-    CategorySampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: Sampling as list of categories
-          items:
-            type: string
-            description: Sampling as list of categories
-    RangeSampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: "Sampling as list of [start, end] timestamp ranges"
-          items:
-            $ref: "#/components/schemas/StartEndRange"
     Sampling:
       type: object
       description: Sampling values
       oneOf:
-      - $ref: "#/components/schemas/TimestampSampling"
-      - $ref: "#/components/schemas/CategorySampling"
-      - $ref: "#/components/schemas/RangeSampling"
+      - type: array
+        description: "Sampling as a flat list of timestamps. Example: [100, 200, 350]"
+        items:
+          type: integer
+          format: int64
+      - type: array
+        description: "Sampling as a flat list of categories. Example: [\"READ\", \"\
+          WRITE\"]"
+        items:
+          type: string
+      - type: array
+        description: "Sampling as a list of start/end range objects. Example: [{\"\
+          start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]"
+        items:
+          $ref: '#/components/schemas/StartEndRange'
     SeriesModel:
       required:
       - seriesId
@@ -3205,25 +3196,13 @@ components:
       properties:
         start:
           type: integer
-          description: Start timestamp of the range
+          description: Start of the range (inclusive).
           format: int64
         end:
           type: integer
-          description: End timestamp of the range
+          description: End of the range (inclusive).
           format: int64
-      description: "Sampling as list of [start, end] timestamp ranges"
-    TimestampSampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: Sampling as list of timestamps
-          items:
-            type: integer
-            description: Sampling as list of timestamps
-            format: int64
+      description: An object representing a closed interval with a start and end.
     XYAxisDescription:
       required:
       - dataType

--- a/API.yaml
+++ b/API.yaml
@@ -2616,34 +2616,25 @@ components:
           type: string
           description: "Type of axis domain: 'range'"
       description: Domain of values supported on a numberical range chart axis.
-    CategorySampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: Sampling as list of categories
-          items:
-            type: string
-            description: Sampling as list of categories
-    RangeSampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: "Sampling as list of [start, end] timestamp ranges"
-          items:
-            $ref: "#/components/schemas/StartEndRange"
     Sampling:
       type: object
       description: Sampling values
       oneOf:
-      - $ref: "#/components/schemas/TimestampSampling"
-      - $ref: "#/components/schemas/CategorySampling"
-      - $ref: "#/components/schemas/RangeSampling"
+      - type: array
+        description: "Sampling as a flat list of timestamps. Example: [100, 200, 350]"
+        items:
+          type: integer
+          format: int64
+      - type: array
+        description: "Sampling as a flat list of categories. Example: [\"READ\", \"\
+          WRITE\"]"
+        items:
+          type: string
+      - type: array
+        description: "Sampling as a list of start/end range objects. Example: [{\"\
+          start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]"
+        items:
+          $ref: '#/components/schemas/StartEndRange'
     SeriesModel:
       required:
       - seriesId
@@ -2685,25 +2676,13 @@ components:
       properties:
         start:
           type: integer
-          description: Start timestamp of the range
+          description: Start of the range (inclusive).
           format: int64
         end:
           type: integer
-          description: End timestamp of the range
+          description: End of the range (inclusive).
           format: int64
-      description: "Sampling as list of [start, end] timestamp ranges"
-    TimestampSampling:
-      required:
-      - sampling
-      type: object
-      properties:
-        sampling:
-          type: array
-          description: Sampling as list of timestamps
-          items:
-            type: integer
-            description: Sampling as list of timestamps
-            format: int64
+      description: An object representing a closed interval with a start and end.
     XYAxisDescription:
       required:
       - dataType

--- a/API.yaml
+++ b/API.yaml
@@ -26,7 +26,7 @@ info:
   license:
     name: Apache 2
     url: http://www.apache.org/licenses/
-  version: 0.5.0
+  version: 0.6.0
 servers:
 - url: https://localhost:8080/tsp/api
 tags:
@@ -2616,31 +2616,26 @@ components:
           type: string
           description: "Type of axis domain: 'range'"
       description: Domain of values supported on a numberical range chart axis.
-    Sampling:
+    Range:
+      required:
+      - end
+      - start
       type: object
-      description: Sampling values
-      oneOf:
-      - type: array
-        description: "Sampling as a flat list of timestamps. Example: [100, 200, 350]"
-        items:
+      properties:
+        start:
           type: integer
+          description: Start of the range (inclusive).
           format: int64
-      - type: array
-        description: "Sampling as a flat list of categories. Example: [\"READ\", \"\
-          WRITE\"]"
-        items:
-          type: string
-      - type: array
-        description: "Sampling as a list of start/end range objects. Example: [{\"\
-          start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]"
-        items:
-          $ref: '#/components/schemas/StartEndRange'
+        end:
+          type: integer
+          description: End of the range (inclusive).
+          format: int64
+      description: An object representing a closed interval with a start and end.
     SeriesModel:
       required:
       - seriesId
       - seriesName
       - style
-      - xValues
       - xValuesDescription
       - yValues
       - yValuesDescription
@@ -2656,7 +2651,29 @@ components:
         style:
           $ref: "#/components/schemas/OutputElementStyle"
         xValues:
-          $ref: "#/components/schemas/Sampling"
+          type: array
+          description: "X values as list of int64 values (e.g. timestamps). Example:\
+            \ [100, 200, 350]. Mutually exclusive with xCategories/xRanges."
+          items:
+            type: integer
+            description: "X values as list of int64 values (e.g. timestamps). Example:\
+              \ [100, 200, 350]. Mutually exclusive with xCategories/xRanges."
+            format: int64
+        xCategories:
+          type: array
+          description: "X values as list of category strings. Example: [\"READ\",\
+            \ \"WRITE\"]. Mutually exclusive with xValues/xRanges."
+          items:
+            type: string
+            description: "X values as list of category strings. Example: [\"READ\"\
+              , \"WRITE\"]. Mutually exclusive with xValues/xRanges."
+        xRanges:
+          type: array
+          description: "X values as list of start/end range objects. Example: [{\"\
+            start\": 10, \"end\": 20}, {\"start\": 50, \"end\": 75}]. Mutually exclusive\
+            \ with xValues/xCategories."
+          items:
+            $ref: "#/components/schemas/Range"
         yValues:
           type: array
           description: Series' Y values
@@ -2668,21 +2685,6 @@ components:
         yValuesDescription:
           $ref: "#/components/schemas/XYAxisDescription"
       description: This model includes the series output style values.
-    StartEndRange:
-      required:
-      - end
-      - start
-      type: object
-      properties:
-        start:
-          type: integer
-          description: Start of the range (inclusive).
-          format: int64
-        end:
-          type: integer
-          description: End of the range (inclusive).
-          format: int64
-      description: An object representing a closed interval with a start and end.
     XYAxisDescription:
       required:
       - dataType


### PR DESCRIPTION
This was incorrectly specified and didn't match the implementation.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/trace-server-protocol/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Fix specification for sampling in xy output.

Part of fixes for https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/issues/236

### How to test

Generate openapi.yaml from corresponding server and compare changes.

### Follow-ups

No follow-ups.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
